### PR TITLE
sh110x: invert display scan direction for rotated hardware layout

### DIFF
--- a/Software/sh1106.h
+++ b/Software/sh1106.h
@@ -20,8 +20,8 @@
 #define SH1107 1
 
 // Direction of display scanning
-#define SH1106_LEFTRIGHT	0	// 0 - horizongal scan direction
-#define SH1106_UPDOWN		0	// 0 - vertical scan direction
+#define SH1106_LEFTRIGHT	1	// 0 - horizongal scan direction
+#define SH1106_UPDOWN		1	// 0 - vertical scan direction
 
 // The SH1106 controller does 132 columns, might be offset
 // One of the random differences to the SH1306


### PR DESCRIPTION
This changes the screen scanning direction definitions to 1, preparing the firmware for the flipped screen layout mentioned in Issue #12. 

Note: This change has only been compile-tested and could not be verified on actual hardware due to a lack of physical components.
