### PR TITLE
prep: fix Makefile to get all submodules

### DIFF
--- a/Software/Makefile
+++ b/Software/Makefile
@@ -15,6 +15,8 @@ flash:
 prep:
 	git submodule init
 	git submodule update --recursive
+	git -C pico-sdk submodule init
+	git -C pico-sdk submodule update --recursive
 	cmake -DPICO_PLATFORM=rp2350 -S . -B build
 
 .PHONY: build


### PR DESCRIPTION
There doesn't appear to be a git submodule init --recursive, so we'll need to manually check out the submodules for pico-sdk as well.