### PR TITLE
Require 4 bytes before reading the SysEx Set Parameter value

### DIFF
--- a/Software/blink.c
+++ b/Software/blink.c
@@ -297,7 +297,7 @@ static void handle_sysex_payload(uint8_t *sysex_buf, size_t sysex_len)
 	uint8_t cmd = sysex_buf[0];
 	if (cmd == 0x01) { // Schema Request
 		schema_tx_index = 0;
-	} else if (cmd == 0x03 && sysex_len >= 3) { // Set Parameter
+	} else if (cmd == 0x03 && sysex_len >= 4) { // Set Parameter
 		uint8_t eff_id = sysex_buf[1];
 		uint8_t pot_idx = sysex_buf[2];
 		uint8_t val = sysex_buf[3];


### PR DESCRIPTION
Small bounds fix in the new SysEx handling.

The Set Parameter command reads sysex_buf[0..3] (cmd, eff_id, pot_idx, val) but only checks sysex_len >= 3. sysex_len includes the command byte, so a valid message is 4 bytes long. A truncated 3-byte message (F0 7D 03 <eff> <pot> F7, no value) passes the check and val is read from sysex_buf[3], which this message never wrote. Since sysex_buf is static and not cleared between messages, that's the leftover value byte from a previous SysEx, so the pot gets set to a stale value instead of the message being ignored. Save Scene just below reads [0]/[1] and checks >= 2, so this is only lining Set Parameter up with that.

I couldn't build the firmware here (no Pico SDK on this machine), so I modeled the byte consumer and the guard in a small script to confirm the behaviour: after a valid write of value 123, a following truncated 3-byte Set Parameter reads 123 back out of buf[3] under >= 3, and is correctly rejected under >= 4.
