### PR TITLE
parametric_eq: fix gain math, pot only delivered ~half the requested dB

### DIFF
--- a/Software/effects/parametric_eq.h
+++ b/Software/effects/parametric_eq.h
@@ -19,12 +19,6 @@ struct {
 	struct biquad_state state[5];
 } peq;
 
-static float peq_pot_A(float db)
-{
-	// A = 10^(db/40), which is 2^(db * LOG2_10 / 40)
-	return pow2(db * (LOG2_10 / 40.0f));
-}
-
 // Fixed Q for the 5-band EQ
 static const float PEQ_Q = 1.0f;
 
@@ -32,11 +26,11 @@ static void parametric_eq_init(unsigned char pot[10])
 {
 	struct biquad_coeff *c = peq.coeff;
 
-	_biquad_loshelf(c+0, fastsincos(parametric_eq_pot0(pot[0]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot1(pot[1])));
-	_biquad_peaking(c+1, fastsincos(parametric_eq_pot2(pot[2]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot3(pot[3])));
-	_biquad_peaking(c+2, fastsincos(parametric_eq_pot4(pot[4]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot5(pot[5])));
-	_biquad_peaking(c+3, fastsincos(parametric_eq_pot6(pot[6]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot7(pot[7])));
-	_biquad_hishelf(c+4, fastsincos(parametric_eq_pot8(pot[8]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot9(pot[9])));
+	_biquad_loshelf(c+0, fastsincos(parametric_eq_pot0(pot[0]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot1(pot[1])));
+	_biquad_peaking(c+1, fastsincos(parametric_eq_pot2(pot[2]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot3(pot[3])));
+	_biquad_peaking(c+2, fastsincos(parametric_eq_pot4(pot[4]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot5(pot[5])));
+	_biquad_peaking(c+3, fastsincos(parametric_eq_pot6(pot[6]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot7(pot[7])));
+	_biquad_hishelf(c+4, fastsincos(parametric_eq_pot8(pot[8]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot9(pot[9])));
 }
 
 static float parametric_eq_step(float in)
@@ -77,11 +71,11 @@ static int peq_magnitude(int x, void *arg)
 	struct biquad_coeff c;
 	unsigned char *pot = arg;
 
-	_biquad_loshelf(&c, fastsincos(parametric_eq_pot0(pot[0]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot1(pot[1]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
-	_biquad_peaking(&c, fastsincos(parametric_eq_pot2(pot[2]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot3(pot[3]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
-	_biquad_peaking(&c, fastsincos(parametric_eq_pot4(pot[4]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot5(pot[5]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
-	_biquad_peaking(&c, fastsincos(parametric_eq_pot6(pot[6]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot7(pot[7]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
-	_biquad_hishelf(&c, fastsincos(parametric_eq_pot8(pot[8]) / SAMPLES_PER_SEC), PEQ_Q, peq_pot_A(parametric_eq_pot9(pot[9]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
+	_biquad_loshelf(&c, fastsincos(parametric_eq_pot0(pot[0]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot1(pot[1]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
+	_biquad_peaking(&c, fastsincos(parametric_eq_pot2(pot[2]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot3(pot[3]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
+	_biquad_peaking(&c, fastsincos(parametric_eq_pot4(pot[4]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot5(pot[5]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
+	_biquad_peaking(&c, fastsincos(parametric_eq_pot6(pot[6]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot7(pot[7]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
+	_biquad_hishelf(&c, fastsincos(parametric_eq_pot8(pot[8]) / SAMPLES_PER_SEC), PEQ_Q, db_to_level(parametric_eq_pot9(pot[9]))); mag_sq *= peq_biquad_mag_sq(&c,w0,w2);
 
 	float mag = sqrtf(mag_sq);
 	if (mag < 0.0001f) mag = 0.0001f;


### PR DESCRIPTION
_biquad_peaking / _biquad_loshelf / _biquad_hishelf (audio/biquad.h) take a gain argument and compute A = sqrtf(gain) internally — i.e. they expect gain = A². Every other caller passes exactly that via db_to_level(db) = 10^(db/20): see klon.h:62, cabsim.h:70, frenchie.h:287.

parametric_eq.h is the lone exception. Its peq_pot_A(db) = 10^(db/40) is the correct RBJ value of A itself — but it's passed in where the function wants A². So the internal sqrtf turns it into 10^(db/80), and a band dialed to +20 dB only produces about +10 dB. Both audio and OLED graph share peq_pot_A, so they agree with each other, but the response undershoots the pot labels ("LS Gain" LINEAR(-20.0 20.0) = 0.0 dB) and the graph's own axis (+20dB -> y=0).

Fix: drop peq_pot_A(), use db_to_level() like the other three effects.

I might be misreading intent here — if thesofter-than-labeled range is deliberate, feel free to ignore. But it looked off against both the dB labels and every other biquad call site, so flagging it.