### PR TITLE
Validate effect ids in the SysEx Set Routing Order command

### DIFF
--- a/Software/blink.c
+++ b/Software/blink.c
@@ -339,13 +339,24 @@ static void handle_sysex_payload(uint8_t *sysex_buf, size_t sysex_len)
 	} else if (cmd == 0x08) { // Set Routing Order
 		routed_effect_count = 0;
 
-		// Routing order
+		// Routing order. Only accept valid, non-duplicate middle
+		// effects - the gate (0) and settings (EFFECT_COUNT-1) are
+		// never part of the chain (same rule as load_scene()). Without
+		// this an out-of-range id would index effects[] out of bounds
+		// in the audio loop, and duplicates would let the append loop
+		// below run effect_chain_len past the end of effect_chain[].
 		for (int i = 1; i < sysex_len && routed_effect_count < 14; i++) {
 			uint8_t eff_id = sysex_buf[i];
-			effect_chain[routed_effect_count++] = eff_id;
-			if (eff_id < EFFECT_COUNT) {
-				effects[eff_id]->target = effects[eff_id]->mix_pot;
+			if (eff_id == 0 || eff_id >= EFFECT_COUNT - 1)
+				continue;
+			bool dup = false;
+			for (int j = 0; j < routed_effect_count; j++) {
+				if (effect_chain[j] == eff_id) { dup = true; break; }
 			}
+			if (dup)
+				continue;
+			effect_chain[routed_effect_count++] = eff_id;
+			effects[eff_id]->target = effects[eff_id]->mix_pot;
 		}
 
 		// Append unrouted effects and set target to 0


### PR DESCRIPTION
Following up on the note in #22 that the "Allow re-ordering effects" reorg probably introduced other bugs. This is one in the same area.

The 0x08 Set Routing Order SysEx handler stores each payload byte into effect_chain[] before validating it. The eff_id < EFFECT_COUNT check only gates the ->target write, not the store, so:

- an out-of-range id (e.g. 200) goes straight into the chain, and the audio loop then indexes effects[200] out of bounds every sample;
- duplicate ids get past the append-unrouted loop below (which assumes the routed part is a distinct set), so a routing order like [3,3,3,...] pushes effect_chain_len up to 27 on a 15-byte array.

load_scene() already validates next_id > 0 && next_id < EFFECT_COUNT - 1 when walking the saved chain, so this just applies the same rule on the live-routing path and skips already-routed ids.

I can't build the firmware here (no Pico SDK on this box), so I modeled the routing-order builder plus the append loop and checked both cases: [200] makes the old code leave 200 in the chain (effects[] OOB), and [3]x14 drives effect_chain_len to 27; with the validation both stay bounded at 14.
