### PR TITLE
fix: give phaser a unique effect priority

### DIFF
--- a/Software/effects/phaser.h
+++ b/Software/effects/phaser.h
@@ -1,5 +1,5 @@
 // NAME: Phaser [PHSR]
-// PRIORITY: 50
+// PRIORITY: 55
 // POT: "LFO" FREQUENCY(25.0 2000.0) = 270.0 ms
 // POT: "Feedback" LINEAR(0.0 0.75) = 0.376
 // POT: "Freq" FREQUENCY(220.0 6460.0) = 1000.0 Hz

--- a/Software/scripts/gen_effects.py
+++ b/Software/scripts/gen_effects.py
@@ -9,7 +9,7 @@ def generate(audio_dir, out_h, out_js, out_md):
     ui_effects = [] # List of dicts for JS/Schema output
     effects_data = []
 
-    for filename in os.listdir(audio_dir):
+    for filename in sorted(os.listdir(audio_dir)):
         if not filename.endswith('.h'):
             continue
         base = filename[:-2]


### PR DESCRIPTION
klon.h and phaser.h both declared `// PRIORITY: 50`. gen_effects.py assigns each effect's ID from its index in a stable sort by priority, over files enumerated via `os.listdir()`. With a priority tie, ordering falls back to filesystem order — which varies by machine/filesystem — so klon and phaser could silently swap their MIDI/SysEx effect IDs between builds. The script's duplicate-ID guard doesn't catch this since post-sort IDs stay unique.

Fix

- Bump phaser to PRIORITY: 55 (unique; sits between klon=50 and flanger=60, leaving klon's ID unchanged).
- Wrap the effect enumeration in sorted(os.listdir(...)) so any future tie breaks deterministically instead of by filesystem order.

Verification

- No duplicate priorities across Software/effects/*.h.
- Ran gen_effects.py: exits clean, stable IDs (Klon=4, Phaser=5).