### PR TITLE
WebMIDI: fix active pot panel title lookup

### DIFF
--- a/Software/WebMIDI/app.js
+++ b/Software/WebMIDI/app.js
@@ -1497,7 +1497,7 @@ appTitleEl.addEventListener('click', () => {
         activePotCc = cc;
         activePotDef = potDef;
 
-        document.getElementById('active-pot-name').textContent = `${effectName} - ${potDef.name}`;
+        document.getElementById('active-pot-title').textContent = `${effectName} - ${potDef.name}`;
         const valDisplay = document.getElementById('active-pot-value');
         if (valDisplay) valDisplay.textContent = formatPotValue(potDef, currentVal);
 


### PR DESCRIPTION
Fix the active pot panel lookup to use the element ID defined in index.html.

setActivePot() queried active-pot-name, while the corresponding title element is named active-pot-title. This caused a null element access when a pot or mix control attempted to display the active control panel.