### PR TITLE
Don't lose a pot update that arrives while an effect is bypassed

### DIFF
--- a/Software/audio/effect.h
+++ b/Software/audio/effect.h
@@ -226,9 +226,19 @@ static __attribute__((noinline)) void __audio_func(make_one_noise)(void)
 		unsigned seq = smp_load_acquire(&effect->seq);
 		if (seq == effect->last)
 			continue;
+
+		//
+		// An effect that isn't running doesn't need its
+		// coefficients recomputed - but don't mark the update as
+		// consumed either, or it just gets lost.  'target' is
+		// already set by the time an effect is routed back in, so
+		// this picks the change up before it can be heard.
+		//
+		if (!effect->mix && !effect->target)
+			continue;
+
 		effect->last = seq;
-		if (effect->mix)
-			effect->init(effect->pot_values[seq & 1]);
+		effect->init(effect->pot_values[seq & 1]);
 	}
 
 	static int disable = 0;


### PR DESCRIPTION
The audio core retires the pot sequence number whether or not it acts on it:

      effect->last = seq;
      if (effect->mix)
              effect->init(effect->pot_values[seq & 1]);

Skipping ->init() for a bypassed effect is deliberate (49db9df), but 'last' moving anyway turns "skip" into "drop", and nothing recomputes the coefficients when the effect comes back. Route the reverb, turn the room size up, unroute, route it again: the UI reads 0.88 and it still sounds like 0.98. So don't retire a sequence number that isn't being acted on.

No Pico SDK here so I couldn't flash it. Modeled the seq/last/mix handshake instead, and the pots and coefficients agree again.