### PR TITLE
Added safety iteration bound to boost fold()

### DIFF
--- a/Software/effects/boost.h
+++ b/Software/effects/boost.h
@@ -23,7 +23,8 @@ static float fold(float in, float level)
 {
 	float fold_scale = 0.5;
 	boost_effect.intense = 1;
-	for (;;) {
+	// Cap iterations to prevent infinite loop on float precision stalls
+	for (int i = 0; i < 20; i++) {
 		float over = (in - level) * fold_scale;
 
 		in = level - over;
@@ -35,6 +36,7 @@ static float fold(float in, float level)
 		if (in <= level)
 			return in;
 	}
+	return in;
 }
 
 static float boost_step(float in)


### PR DESCRIPTION
The fold() function in boost.h relies on an unbounded for (;;) loop. While it mathematically converges by halving the overshoot, floating-point precision limits can theoretically cause the convergence to stall just outside the threshold. If this happens, it hangs the audio core indefinitely.

Added a hard limit of 20 iterations to guarantee bounded execution time for realtime safety. If it hits the limit, it returns the closest approximated value.