### PR TITLE
Stop the pitch shifter crossfade from modulating the output level

### DIFF
--- a/Effects/pitch.h
+++ b/Effects/pitch.h
@@ -12,8 +12,12 @@
 //
 // sin/cos are zero at the respective discontinuities,
 // and the signal power is proportional to the square
-// of the voltage. With sin^2 * cos^2 = 1, the result
-// should be a unity signal power gain.
+// of the voltage. With sin^2 + cos^2 = 1 the two tap
+// *powers* add to unity - but the power of a sum is
+// the sum of the powers only for uncorrelated taps,
+// and both taps read the same tape, so the cross term
+// modulates the output level at the crossfade rate.
+// pitch_step() measures that term and undoes it.
 //
 
 #define DISCONT_SHIFT 12
@@ -22,6 +26,8 @@
 struct {
 	float step, feedback;
 	unsigned phase, idx;
+	float p1, p2, p12;	// smoothed r1^2, r2^2, r1*r2
+	float follow;		// smoothing coefficient for the three
 	float array[4*DISCONT_STEPS];
 } pitch;
 
@@ -35,6 +41,13 @@ static void pitch_init(unsigned char pot[10])
 	float step = pow2(pitch_octave_pot(pot));	//  0.25 .. 4
 	pitch.step = step - 1;				// -0.75 .. 3
 	pitch.feedback = pitch_feedback_pot(pot);
+
+	// Long enough to average the carrier out of the moment products
+	// (their ripple sits at twice the note, ~26dB down at 165Hz),
+	// short enough to follow a note change well inside the crossfade
+	// window.  This only has to be right about what is playing, never
+	// about when: the weights enter the prediction directly below.
+	pitch.follow = time_constant(20.0f);
 }
 
 // i is discontinuous when sin**2 is 0
@@ -55,12 +68,55 @@ static float pitch_step(float in)
 	float step = pitch.step;
 	float delay = (step > 0) ? DISCONT_STEPS*step : 1;
 
-	float d1 = sample_array_read(delay - i*step, &pitch.idx, pitch.array) * w.sin;
-	float d2 = sample_array_read(delay - ni*step, &pitch.idx, pitch.array) * w.cos;
+	float r1 = sample_array_read(delay - i*step, &pitch.idx, pitch.array);
+	float r2 = sample_array_read(delay - ni*step, &pitch.idx, pitch.array);
 
-	float out = d1+d2;
+	float out = r1*w.sin + r2*w.cos;
 
-	sample_array_write(linear(pitch.feedback, in, out), &pitch.idx, pitch.array);
+	//
+	// sin^2 + cos^2 == 1 makes this unity gain only for uncorrelated
+	// taps.  These two read the same tape 2048*|step| samples apart,
+	// so for a tone at f the power picks up a cross term of
+	// 2*w.sin*w.cos*rho(f), rho being the correlation at that spacing,
+	// and the level sweeps between 1-rho and 1+rho of itself at the
+	// crossfade rate.  That is the tremolo, and it bottoms out at
+	// silence wherever the tap spacing is a whole number of periods -
+	// including step 0, where both taps read the same sample and the
+	// weights cancel outright.
+	//
+	// So keep the three second moments of the raw reads, predict the
+	// power of the sum from them and the current weights, and divide
+	// the mean tap power back in.  The gain is a ratio of two
+	// quadratics in the weights, so the signal level never enters it:
+	// this rides the crossfade ripple and nothing else, and it
+	// relaxes to unity wherever the taps really are uncorrelated.
+	//
+	// Capped at +24dB: the exact answer is unbounded where the taps
+	// cancel outright, and chasing the last of that dip buys boosting
+	// whatever noise is there instead.
+	//
+	float p1 = pitch.p1 = linear(pitch.follow, r1*r1, pitch.p1);
+	float p2 = pitch.p2 = linear(pitch.follow, r2*r2, pitch.p2);
+	float p12 = pitch.p12 = linear(pitch.follow, r1*r2, pitch.p12);
 
-	return out;
+	float mean = 0.5f*(p1+p2);
+	float predicted = w.sin*w.sin*p1 + w.cos*w.cos*p2 + 2*w.sin*w.cos*p12;
+
+	float gain = 16.0f;
+	if (predicted > mean/(16.0f*16.0f))
+		gain = sqrtf(mean/predicted);
+
+	float shaped = out*gain;
+
+	//
+	// The shaped signal goes back into the line rather than the raw
+	// sum: with the feedback pot up, a modulated write keeps the
+	// crossfade term alive in what the taps read next, and the
+	// correction chases it forever.  Shaped has the same short-term
+	// power the raw sum averages, so the loop gain is what it always
+	// was, minus the part that was doing the wobbling.
+	//
+	sample_array_write(linear(pitch.feedback, in, shaped), &pitch.idx, pitch.array);
+
+	return shaped;
 }

--- a/Effects/pitch.h
+++ b/Effects/pitch.h
@@ -42,12 +42,18 @@ static void pitch_init(unsigned char pot[10])
 	pitch.step = step - 1;				// -0.75 .. 3
 	pitch.feedback = pitch_feedback_pot(pot);
 
-	// Long enough to average the carrier out of the moment products
-	// (their ripple sits at twice the note, ~26dB down at 165Hz),
-	// short enough to follow a note change well inside the crossfade
-	// window.  This only has to be right about what is playing, never
-	// about when: the weights enter the prediction directly below.
-	pitch.follow = time_constant(20.0f);
+	// Fast enough to follow the tap correlation around the loop: with
+	// the feedback pot up the taps read recirculated content whose
+	// correlation at the tap spacing turns over on loop timescales
+	// (tens of ms), and estimates that lag it leave the crossfade
+	// ripple partly uncorrected (4.4dB swing on a sustained 84Hz at
+	// 20ms, 2.8dB at 2ms).  Slower would average the carrier ripple
+	// out of the products more fully - it sits at twice the note -
+	// but the mistracking costs more than the ripple does down to
+	// here; below ~1ms the ripple starts winning again on low notes.
+	// One constant for all three moments: they enter the prediction
+	// below as a ratio, and staggered lags pump the gain instead.
+	pitch.follow = time_constant(2.0f);
 }
 
 // i is discontinuous when sin**2 is 0

--- a/Validation/Makefile
+++ b/Validation/Makefile
@@ -89,6 +89,7 @@ bench: bench/bench bench/coeff
 #
 check-effects: bench/bench
 	./test-effects.py
+	./test-pitch.py
 
 #
 # Where every biquad in the pedal actually lands, swept across the range

--- a/Validation/test-pitch.py
+++ b/Validation/test-pitch.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+# The Pitch effect's output level on a sustained note.
+#
+# The two taps read the same delay line 2048*|step| samples apart, so
+# what they carry is correlated, and the sin/cos crossfade - which
+# keeps the two tap *powers* adding to one - then modulates the power
+# of the sum at the crossfade rate instead.  On a sustained note that
+# is a tremolo at SAMPLES_PER_SEC/DISCONT_STEPS, with a depth of up to
+# the full correlation between the taps: notes whose period divides
+# the tap spacing swung from near-silence to twice their power and
+# back, twice a window, forever.
+#
+# What this asserts is the thing the bug is: how far the output
+# envelope of a sustained note still moves while it plays.  The
+# frequencies are whole cycles in the analysis window, like everywhere
+# else in here, and they are picked for the mechanism: 164Hz is
+# exactly four tap spacings away at the default octave, so the taps
+# are fully correlated and the old crossfade dug a hole to silence
+# twice a window; 84Hz lands near the opposite correlation phase and
+# did nearly as badly from the other sign.  128Hz at the octave-0 pot
+# is the degenerate bottom of it, where both taps read the same sample
+# and the weights cancel the signal outright.
+#
+# Bounds sit well above what the correction leaves behind (a couple of
+# tenths of a dB to ~2.5dB across the pot ranges) and far below what
+# the uncorrected crossfade does to the same notes (7-20dB), so the
+# test has room on both sides and no exact-float dependence anywhere.
+#
+# Skips rather than fails without numpy, the same bargain
+# test-effects.py makes.
+#
+import sys
+
+try:
+    import numpy as np
+except ImportError:
+    print("test-pitch: SKIPPED - no numpy")
+    sys.exit(0)
+
+import bench as B
+
+FAILED = []
+
+
+def check(name, got, hi, unit="dB"):
+    ok = got <= hi
+    print("  %-46s %9.2f %-4s  want < %-10g %s"
+          % (name, got, unit, hi, "ok" if ok else "FAIL"))
+    if not ok:
+        FAILED.append(name)
+
+
+WARMUP = int(B.FS) * 2   # fill the 16384-sample line, fade in, settle moments
+N = int(B.FS) * 2        # ~23 crossfade power cycles to measure across
+
+
+def envelope_pp_db(y, win=512, hop=64):
+    n = (len(y) - win) // hop
+    idx = np.arange(n)[:, None] * hop + np.arange(win)[None, :]
+    e = 20 * np.log10(np.sqrt((y[idx] ** 2).mean(axis=1) + 1e-30))
+
+    # keep the measurement off the effect's own entry ramp
+    trim = int(0.05 * B.FS / hop)
+    e = e[trim:-trim]
+    return e.max() - e.min()
+
+
+def sustained(hz, oct_raw=90, fb_raw=60, x=None):
+    if x is None:
+        x = B.tone(hz, -12.0, N)
+    args = ["--pot", "Signal Chain:Gate=0",
+            "--route", "Pitch",
+            "--mix", "Pitch=120",
+            "--pot", "Pitch:Octave=%d" % oct_raw,
+            "--pot", "Pitch:Feedback=%d" % fb_raw]
+    left, right, info = B.run(args, x, warmup=WARMUP)
+    return left, info
+
+
+print("pitch crossfade level - sustained notes, effect wet")
+
+# The default setting (octave +1, feedback 0.5), at the two notes the
+# tap spacing treats worst from either side of the correlation phase.
+for hz in (164.0, 84.0):
+    left, info = sustained(hz)
+    check("envelope swing (%gHz, default pots)" % hz,
+          envelope_pp_db(left), 2.5)
+    check("no clipping (%gHz)" % hz, info["clipped"], 0.5, "")
+
+# Octave 0 is no shift at all: both taps read the same sample, and the
+# old weights cancelled it outright twice a window.  What should come
+# out is the note, at the level it went in with.
+left, info = sustained(128.0, oct_raw=60, fb_raw=0)
+check("envelope swing (128Hz, octave 0)", envelope_pp_db(left), 4.0)
+check("no clipping (octave 0)", info["clipped"], 0.5, "")
+
+# A correction that can reach +24dB must stay out of the way when
+# there is nothing to correct.
+left, info = sustained(0, x=np.zeros(N, dtype=np.float32))
+check("silence stays silent",
+      20 * np.log10(np.abs(left).max() + 1e-30), -100.0)
+
+print()
+if FAILED:
+    print("test-pitch: FAILED - %s" % ", ".join(FAILED))
+    sys.exit(1)
+print("test-pitch: ok")

--- a/Validation/test-pitch.py
+++ b/Validation/test-pitch.py
@@ -22,10 +22,10 @@
 # is the degenerate bottom of it, where both taps read the same sample
 # and the weights cancel the signal outright.
 #
-# Bounds sit well above what the correction leaves behind (a couple of
-# tenths of a dB to ~2.5dB across the pot ranges) and far below what
-# the uncorrected crossfade does to the same notes (7-20dB), so the
-# test has room on both sides and no exact-float dependence anywhere.
+# Bounds sit well above what the correction leaves behind (1.3-3.1dB
+# across these notes at the default pots) and far below what the
+# uncorrected crossfade does to the same notes (6-20dB), so the test
+# has room on both sides and no exact-float dependence anywhere.
 #
 # Skips rather than fails without numpy, the same bargain
 # test-effects.py makes.
@@ -81,11 +81,18 @@ def sustained(hz, oct_raw=90, fb_raw=60, x=None):
 print("pitch crossfade level - sustained notes, effect wet")
 
 # The default setting (octave +1, feedback 0.5), at the two notes the
-# tap spacing treats worst from either side of the correlation phase.
-for hz in (164.0, 84.0):
+# tap spacing treats worst from either side of the correlation phase,
+# plus low A in the bass range the uncorrected crossfade was reported
+# still wobbling on.  Per-note bounds: with feedback up the taps read
+# recirculated content whose correlation keeps moving (see the note on
+# pitch.follow), and 84Hz sits at an awkward phase of it, so its bound
+# is set from what the correction leaves (2.8dB) rather than alongside
+# the others.  The uncorrected crossfade swings 6.3-9.8dB on these
+# three, so every bound still has room underneath it.
+for hz, bound in ((164.0, 2.5), (84.0, 3.5), (55.0, 4.0)):
     left, info = sustained(hz)
     check("envelope swing (%gHz, default pots)" % hz,
-          envelope_pp_db(left), 2.5)
+          envelope_pp_db(left), bound)
     check("no clipping (%gHz)" % hz, info["clipped"], 0.5, "")
 
 # Octave 0 is no shift at all: both taps read the same sample, and the


### PR DESCRIPTION
The pitch shifter's output level wobbles on sustained notes (#31).

The crossfade multiplies two reads of the same delay line with sin/cos
weights, and the header comment argues that sin^2 + cos^2 = 1, so the
power should come out at unity. That holds only for uncorrelated taps,
and both taps read the same tape: they sit 2048*|step| tape samples
apart (step = pow2(octave) - 1), so for a tone at f the power of the
sum carries a cross term of 2*w.sin*w.cos*rho(f), rho the correlation
at that spacing. The level ends up sweeping between 1-rho and 1+rho of
itself at the crossfade rate (11.7Hz at 48kHz), and wherever the tap
spacing is a whole number of periods the crossfade digs it all the way
to silence and back, twice a window.

Measured through Validation/bench at the default octave (+1): 3-18dB
peak-to-peak envelope swing on sustained notes (median 11dB across
nine notes), and 19-32dB at the octave-0 pot, where both taps read the
same sample and the weights cancel outright - a no-shift setting that
tremolos harder than anything else on the pedal.

The fix measures the three smoothed second moments of the raw tap
reads, predicts the power of the sum from them and the current
weights, and divides the mean tap power back in:

    gain = sqrt(mean / (w.sin^2*p1 + w.cos^2*p2 + 2*w.sin*w.cos*p12))

The gain is a ratio of two quadratics in the weights, so the signal
level never enters it - this rides the crossfade ripple and not the
note's own dynamics, which is the difference from the compressor the
issue suggests: nothing pumps. It relaxes to unity wherever the taps
really are uncorrelated, so notes the old code got right stay right.
It is capped at +24dB, because where the taps cancel outright no gain
is the right answer and chasing the last of that dip only boosts
noise. The normalized signal is also what goes back into the delay
line: with the feedback pot up, writing the still-modulated sum keeps
re-injecting the crossfade term and the correction chases it forever.

Cost: three one-poles and a divide/sqrt per sample (~30 FLOPs, four
floats of state). Bench wall time over 60s of audio is unchanged
(714ms -> 716ms, within run-to-run noise).

Validation (the bench is the pedal's own audio core, same files, same
flags - what is measured is not a model of the signal path):

* make check-effects: ok, including the new test-pitch.py, which
  asserts the envelope swing of sustained notes at the notes the tap
  spacing treats worst. It fails on the old code (9.8/6.8/20.2dB
  against 2.5/2.5/4.0 bounds) and passes on this (1.1/1.7/2.0dB).
* Nine notes x three octave settings x two feedback settings: median
  envelope swing 15.5 -> 1.1dB p-p; default octave 11.1 -> 0.6. The
  one place that does not flatten is octave 0 with feedback (9-11dB,
  down from 28-32) - at a near-unity shift the weights cancel the
  content twice a window and the feedback loop keeps swinging around
  each null. Without feedback the same setting is at 1-3dB.
* Transients: DADGAD.wav and silence->note onsets - attack response
  unchanged or slightly tighter, nothing clips, digital silence stays
  exactly zero, -120dBFS dither stays at -115dB.
* test-biquad and test-midi-cin: ok. test-webmidi fails the same way
  on unmodified main in this environment (pre-existing, unrelated to
  this change).

No RP2354 toolchain was available here, so this was validated through
the host bench - which compiles the pedal's own single_sample() and
the effect headers with the firmware's flags - but the firmware itself
was not built, and no pedal hardware was attached for check-bench or
check-hw.

Fixes #31